### PR TITLE
Create Logging Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+logs/

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ OUTFILE=$(OUT_DIR)TerminalEngine.exe
 all: $(OBJECTS)
 	g++ $(OBJECTS) $(FLAGS) -o $(OUTFILE)
 
+debug: FLAGS += $(DEBUG)
+debug: all
+
 -include $(DEPENDS)
 
 $(OUT_DIR)%.o : $(SRC_DIR)%.cpp

--- a/inc/input.hpp
+++ b/inc/input.hpp
@@ -10,6 +10,7 @@
 #include "entity.hpp"
 
 #include "events.hpp"
+#include "log.hpp"
 
 #include <functional>
 #include <unordered_map>
@@ -62,6 +63,7 @@ public:
 	void removeActionMapping(int);
 
 private:
+	static Log log;
 	void threadHandler();
 
 	std::unordered_map<int, Action> actionMap;

--- a/inc/log.hpp
+++ b/inc/log.hpp
@@ -8,12 +8,13 @@
 
 class Log {
 public:
-	enum LogType{Min, Debug, Info, Warning, Error, Fatal};
 	struct Entry {
 		std::chrono::system_clock::time_point timestamp;
-		LogType severity;
+		enum LogType{None, Debug, Info, Warning, Error, Fatal} severity;
 		std::string message;
 		std::string sender;
+
+		friend std::ostream& operator<<(std::ostream&, const Entry&);
 	};
 
 	Log(std::string, std::string);
@@ -22,8 +23,8 @@ public:
 	void setParent(Log*);
 
 	void log(std::string);
-	void log(std::string, LogType);
-	void log(std::string, LogType, std::string);
+	void log(std::string, Entry::LogType);
+	void log(std::string, Entry::LogType, std::string);
 
 private:
 	void writeEntry(Entry);

--- a/inc/log.hpp
+++ b/inc/log.hpp
@@ -6,19 +6,18 @@
 #include <string>
 #include <chrono>
 
-using std::chrono::system_clock;
-
 class Log {
 public:
 	enum LogType{Min, Debug, Info, Warning, Error, Fatal};
 	struct Entry {
-		system_clock::time_point timestamp;
+		std::chrono::system_clock::time_point timestamp;
 		LogType severity;
 		std::string message;
 		std::string sender;
 	};
 
 	Log(std::string, std::string);
+	virtual ~Log();
 
 	void setParent(Log*);
 

--- a/inc/log.hpp
+++ b/inc/log.hpp
@@ -1,0 +1,40 @@
+/*
+ * log.hpp
+ */
+
+#include <fstream>
+#include <string>
+#include <chrono>
+
+using std::chrono::system_clock;
+
+class Log {
+public:
+	enum LogType{Min, Debug, Info, Warning, Error, Fatal};
+	struct Entry {
+		system_clock::time_point timestamp;
+		LogType severity;
+		std::string message;
+		std::string sender;
+	};
+
+	Log(std::string, std::string);
+
+	void setParent(Log*);
+
+	void log(std::string);
+	void log(std::string, LogType);
+	void log(std::string, LogType, std::string);
+
+private:
+	void writeEntry(Entry);
+
+	std::string name;
+	std::ofstream logfile;
+
+	Log *parent;
+};
+
+namespace Engine {
+	extern Log log;
+};

--- a/inc/log.hpp
+++ b/inc/log.hpp
@@ -2,6 +2,9 @@
  * log.hpp
  */
 
+#ifndef _LOG_HPP_
+#define _LOG_HPP_
+
 #include <fstream>
 #include <string>
 #include <chrono>
@@ -18,6 +21,7 @@ public:
 	};
 
 	Log(std::string, std::string);
+	Log(std::string, std::string, Log*);
 	virtual ~Log();
 
 	void setParent(Log*);
@@ -38,3 +42,5 @@ private:
 namespace Engine {
 	extern Log log;
 };
+
+#endif

--- a/inc/utils.hpp
+++ b/inc/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * utils.h
+ * utils.hpp
  *
  * General utilities used throughout the program
  */
@@ -7,8 +7,12 @@
 #ifndef _UTILS_H_
 #define _UTILS_H_
 
+#include <string>
+
 struct Utils {
 	static int nextID(int*);
+	
+	static void create_directories(std::string);
 };
 
 #endif

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,6 +9,8 @@
 #include <conio.h>
 #include <winuser.h>
 
+Log Input::log{"Input", "./logs/input.log"};
+
 static void aMove(Entity *target, int input) {
 	Coord ePos = target->getPos();
 
@@ -219,6 +221,8 @@ void Input::threadHandler() {
 			};
 		};
 		Engine::eventBus.queueEvent(event);
+
+		Input::log.log("Received keypress", Log::Entry::LogType::Debug, "Handler");
 	
 		//Select action and queue event
 		//Have quit event contain pointer to Input

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,6 +9,8 @@
 #include <conio.h>
 #include <winuser.h>
 
+using LogType = Log::Entry::LogType;
+
 Log Input::log{"Input", "./logs/input.log"};
 
 static void aMove(Entity *target, int input) {
@@ -194,7 +196,7 @@ void Input::removeActionMapping(int input) {
  * Thread exits on generating QuitEvent
  */
 void Input::threadHandler() {
-	std::cout << "<input>Input thread" << std::endl;
+	Input::log.log("Input thread started", LogType::Info, "Handler");
 	while(this->active) {
 		INPUT_RECORD input = getInput(100);
 		int scanCode;
@@ -222,7 +224,7 @@ void Input::threadHandler() {
 		};
 		Engine::eventBus.queueEvent(event);
 
-		Input::log.log("Received keypress", Log::Entry::LogType::Debug, "Handler");
+		Input::log.log("Received keypress", LogType::Debug, "Handler");
 	
 		//Select action and queue event
 		//Have quit event contain pointer to Input

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -4,6 +4,8 @@
 
 #include "log.hpp"
 
+#include "utils.hpp"
+
 using std::chrono::system_clock;
 
 //Must construct in-place because ofstream is non-copyable
@@ -11,6 +13,7 @@ Log Engine::log{"Master", "./logs/master.log"};
 
 Log::Log(std::string name, std::string logfile) {
 	this->name = name;
+	Utils::create_directories(logfile.substr(0, logfile.rfind("/")));
 	this->logfile.open(logfile, std::ios::out | std::ios::app);
 };
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,33 @@
+/*
+ * log.cpp
+ */
+
+#include "log.hpp"
+
+Log Engine::log = Log("Master", "./logs/master.log");
+
+Log::Log(std::string name, std::string logfile) {
+	this->name = name;
+	this->logfile.open(logfile, std::ios::out | std::ios::app);
+};
+
+void Log::setParent(Log *parent) {
+	this->parent = parent;
+};
+
+void Log::log(std::string message) {
+	this->log(message, Log::LogType::Info, "");
+};
+
+void Log::log(std::string message, Log::LogType severity) {
+	this->log(message, severity, "");
+};
+
+void Log::log(std::string message, Log::LogType severity, std::string sender) {
+	Entry entry{system_clock::now(), severity, message, ""};
+
+	this->writeEntry(entry);
+};
+
+void Log::writeEntry(Entry entry) {
+};

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -4,11 +4,18 @@
 
 #include "log.hpp"
 
-Log Engine::log = Log("Master", "./logs/master.log");
+using std::chrono::system_clock;
+
+//Must construct in-place because ofstream is non-copyable
+Log Engine::log{"Master", "./logs/master.log"};
 
 Log::Log(std::string name, std::string logfile) {
 	this->name = name;
 	this->logfile.open(logfile, std::ios::out | std::ios::app);
+};
+
+Log::~Log() {
+	this->logfile.close();
 };
 
 void Log::setParent(Log *parent) {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -11,20 +11,16 @@
 using std::chrono::system_clock;
 
 //Must construct in-place because ofstream is non-copyable
-Log Engine::log{"Master", "./logs/master.log"};
+Log Engine::log{"Master", "./logs/master.log", nullptr};
 
-Log::Log(std::string name, std::string logfile) {
-	static bool master = true;
+Log::Log(std::string name, std::string logfile) : Log(name, logfile, &Engine::log){};
 
+Log::Log(std::string name, std::string logfile, Log *parent) {
 	this->name = name;
 	Utils::create_directories(logfile.substr(0, logfile.rfind("/")));
 	this->logfile.open(logfile, std::ios::out | std::ios::app);
 
-	this->parent = &Engine::log;
-	if(master) {
-		this->parent = nullptr;
-		master = false;
-	};
+	this->parent = parent;
 };
 
 Log::~Log() {
@@ -85,7 +81,10 @@ std::ostream& operator<<(std::ostream &os, const Log::Entry &entry) {
 			break;
 	};
 
-	os << " (" << entry.sender << ") : " << entry.message;
+	if(entry.sender.size() > 0)
+		os << " (" << entry.sender << ")";
+
+	os << " : " << entry.message;
 
 	return os;
 };

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -6,6 +6,8 @@
 
 #include "utils.hpp"
 
+#include <ctime>
+
 using std::chrono::system_clock;
 
 //Must construct in-place because ofstream is non-copyable
@@ -42,7 +44,7 @@ void Log::log(std::string message, Log::Entry::LogType severity) {
 };
 
 void Log::log(std::string message, Log::Entry::LogType severity, std::string sender) {
-	Entry entry{system_clock::now(), severity, message, ""};
+	Entry entry{system_clock::now(), severity, message, sender};
 
 	this->writeEntry(entry);
 };
@@ -57,7 +59,10 @@ void Log::writeEntry(Entry entry) {
 };
 
 std::ostream& operator<<(std::ostream &os, const Log::Entry &entry) {
-	os << system_clock::to_time_t(entry.timestamp) << "\t";
+	std::time_t timestamp = system_clock::to_time_t(entry.timestamp);
+	std::string str{ctime(&timestamp)};
+	str.pop_back();
+	os << str << " -- ";
 
 	switch(entry.severity) {
 		case Log::Entry::LogType::None:

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -12,9 +12,17 @@ using std::chrono::system_clock;
 Log Engine::log{"Master", "./logs/master.log"};
 
 Log::Log(std::string name, std::string logfile) {
+	static bool master = true;
+
 	this->name = name;
 	Utils::create_directories(logfile.substr(0, logfile.rfind("/")));
 	this->logfile.open(logfile, std::ios::out | std::ios::app);
+
+	this->parent = &Engine::log;
+	if(master) {
+		this->parent = nullptr;
+		master = false;
+	};
 };
 
 Log::~Log() {
@@ -26,18 +34,53 @@ void Log::setParent(Log *parent) {
 };
 
 void Log::log(std::string message) {
-	this->log(message, Log::LogType::Info, "");
+	this->log(message, Log::Entry::LogType::Info, "");
 };
 
-void Log::log(std::string message, Log::LogType severity) {
+void Log::log(std::string message, Log::Entry::LogType severity) {
 	this->log(message, severity, "");
 };
 
-void Log::log(std::string message, Log::LogType severity, std::string sender) {
+void Log::log(std::string message, Log::Entry::LogType severity, std::string sender) {
 	Entry entry{system_clock::now(), severity, message, ""};
 
 	this->writeEntry(entry);
 };
 
 void Log::writeEntry(Entry entry) {
+	this->logfile << entry << std::endl;
+
+	if(this->parent) {
+		entry.sender = this->name + ":" + entry.sender;
+		this->parent->writeEntry(entry);
+	};
+};
+
+std::ostream& operator<<(std::ostream &os, const Log::Entry &entry) {
+	os << system_clock::to_time_t(entry.timestamp) << "\t";
+
+	switch(entry.severity) {
+		case Log::Entry::LogType::None:
+			os << "None";
+			break;
+		case Log::Entry::LogType::Debug:
+			os << "Debug";
+			break;
+		case Log::Entry::LogType::Info:
+			os << "Info";
+			break;
+		case Log::Entry::LogType::Warning:
+			os << "Warning";
+			break;
+		case Log::Entry::LogType::Error:
+			os << "Error";
+			break;
+		case Log::Entry::LogType::Fatal:
+			os << "Fatal";
+			break;
+	};
+
+	os << " (" << entry.sender << ") : " << entry.message;
+
+	return os;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "entity.hpp"
 #include "input.hpp"
 #include "events.hpp"
+#include "log.hpp"
 
 #include <windows.h>
 #include <iostream>
@@ -127,6 +128,9 @@ int main() {
 
 	//Render window
 	window.render();
+
+	//Test log
+	Engine::log.log("Initialization complete", Log::Entry::LogType::Info, "Main");
 
 	//Print out manager
 	std::cout << manager << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,11 @@
 
 #include <string>
 
+#include <sstream>
+
 #include <random>
+
+using LogType = Log::Entry::LogType;
 
 static bool running = true;
 static Entity *primary;
@@ -131,11 +135,14 @@ int main() {
 
 	//Test log
 	Log testLog{"Test", "./logs/test.log"};
-	testLog.log("Testing nested log");
-	Engine::log.log("Initialization complete", Log::Entry::LogType::Info, "Main");
+	LogType testLogType = LogType::Debug;
+	testLog.log("Testing nested log", LogType::Info, "Main");
+	Engine::log.log("Initialization complete", LogType::Info, "Main");
 
 	//Print out manager
-	std::cout << manager << std::endl;
+	std::stringstream sstr{};
+	sstr << manager;
+	testLog.log(sstr.str(), testLogType, "Manager");
 
 	//Attempt to move player
 	Coord testCoord = {2,5};
@@ -156,14 +163,19 @@ int main() {
 	//Print out list of entities
 	std::vector<Entity*> playerList = manager.getEntities();
 
-	std::cout << "Printing entities" << std::endl;
+	testLog.log("Printing entities", testLogType, "Main");
 	for(unsigned int i = 0; i < playerList.size(); ++i) {
-		std::cout << "\t" << *playerList[i] << std::endl;
+		sstr.str("\t");
+		sstr << *playerList[i];
+		testLog.log(sstr.str(), testLogType, "Main");
 	};
 
 	//Get inputs
-	std::cout << "Spawning thread...";
-	if(!input.spawnThread()) return 1;
+	testLog.log("Spawning thread...", LogType::Info, "Main");
+	if(!input.spawnThread()) {
+		testLog.log("Failed, exiting", LogType::Fatal, "Main");
+		return 1;
+	};
 
 	//Setup event handling
 	//InputEvent
@@ -179,10 +191,6 @@ int main() {
 	int typeQEID = Engine::eventBus.registerEventType(&qeType);
 	Engine::eventBus.registerEventHandler(typeQEID, &quitHandler);
 
-	std::cout << "Wait" << std::endl;
-	Sleep(2000);
-	
-	std::cout << "Run" << std::endl;
 	while(running) {
 		//Event* first = Engine::eventBus.getFirstEvent();
 		//const char* info = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,6 +130,8 @@ int main() {
 	window.render();
 
 	//Test log
+	Log testLog{"Test", "./logs/test.log"};
+	testLog.log("Testing nested log");
 	Engine::log.log("Initialization complete", Log::Entry::LogType::Info, "Main");
 
 	//Print out manager

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,8 +6,21 @@
 
 #include "utils.hpp"
 
+//#include <sys/stat.h>
+//#include <direct.h> //Thanks, windows
+#include <fileapi.h>
+
 int Utils::nextID(int *tracker) {
 	int r = *tracker;
 	*tracker += 1;
 	return r;
+};
+
+void Utils::create_directories(std::string path) {
+	size_t pos = 0;
+
+	while(pos != std::string::npos) {
+		pos = path.find("/", pos+1);
+		CreateDirectoryA(path.substr(0, pos).c_str(), nullptr);
+	};
 };


### PR DESCRIPTION
Resolves #6.

Changes:
 - Create `Log` class
 - Create master log at `Engine::log`
 - Logs will by default have the master log as a parent
 - Each log entry has a timestamp, message, severity, and sender
 - Existing debug print statements changed to send to log