### PR TITLE
Add Ability to Interrupt Input Thread

### DIFF
--- a/inc/input.hpp
+++ b/inc/input.hpp
@@ -72,6 +72,8 @@ private:
 
 	int timeout = 200;
 	bool active = false;
+
+	HANDLE intrHandle;
 };
 
 struct InputEvent : Event {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -80,6 +80,7 @@ static INPUT_RECORD getInput(int timeout, HANDLE interruptHandle) {
 			buffered = cnt;
 		} else {
 			input[0].EventType = 0;
+			SetConsoleMode(handle, mode);
 			return input[0];
 		};
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -51,13 +51,15 @@ const std::unordered_map<int, Action> defaultMap = {
 	{Input::Key::Right, MoveAction}
 };
 
-static INPUT_RECORD getInput(int timeout) {
+static INPUT_RECORD getInput(int timeout, HANDLE interruptHandle) {
 	const int bufferSize = 10;
 
 	DWORD mode;
 
 	static INPUT_RECORD input[bufferSize];
 	static int buffered = 0;
+
+	HANDLE waitHandles[2] = {nullptr, interruptHandle};
 
 	if(buffered == 0) {
 		//Std handle
@@ -68,7 +70,8 @@ static INPUT_RECORD getInput(int timeout) {
 
 		//Set mode
 		SetConsoleMode(handle, 0);
-		if(WaitForSingleObject(handle, timeout) == WAIT_OBJECT_0) {
+		waitHandles[0] = handle;
+		if(WaitForMultipleObjects(2, waitHandles, false, timeout) == WAIT_OBJECT_0) {
 			DWORD cnt;
 
 			//Get input event
@@ -95,29 +98,29 @@ static INPUT_RECORD getInput(int timeout) {
 };
 
 int Input::getInputKey() {
-	INPUT_RECORD input = getInput(0);
+	INPUT_RECORD input = getInput(0, 0);
 
 	if(input.EventType == KEY_EVENT)
-		return getInput(0).Event.KeyEvent.wVirtualKeyCode;
+		return getInput(0, 0).Event.KeyEvent.wVirtualKeyCode;
 
 	return 0;
 };
 
 int Input::getInputScan() {
-	INPUT_RECORD input = getInput(0);
+	INPUT_RECORD input = getInput(0, 0);
 
 	if(input.EventType == KEY_EVENT)
-		return getInput(0).Event.KeyEvent.wVirtualScanCode;
+		return getInput(0, 0).Event.KeyEvent.wVirtualScanCode;
 
 	return 0;
 };
 
-Input::Input() {
-	this->actionMap = defaultMap;
-};
+Input::Input() : Input(defaultMap) {};
 
 Input::Input(std::unordered_map<int, Action> actionMap) {
 	this->actionMap = actionMap;
+
+	this->intrHandle = CreateEventA(0, true, false, 0);
 };
 
 /*
@@ -125,6 +128,8 @@ Input::Input(std::unordered_map<int, Action> actionMap) {
  */
 Input::~Input() {
 	this->active = false;
+
+	PulseEvent(this->intrHandle);
 	if(this->thread->joinable()) this->thread->join();
 };
 
@@ -198,7 +203,7 @@ void Input::removeActionMapping(int input) {
 void Input::threadHandler() {
 	Input::log.log("Input thread started", LogType::Info, "Handler");
 	while(this->active) {
-		INPUT_RECORD input = getInput(100);
+		INPUT_RECORD input = getInput(10000, this->intrHandle);
 		int scanCode;
 
 		if(input.EventType == KEY_EVENT && input.Event.KeyEvent.bKeyDown)


### PR DESCRIPTION
Resolves #10.

The static function `getInput` now uses `WaitForMultipleObjects` and takes the handle of an interrupt event as an argument.  This handle is generated in the constructor and used by `Input::threadHandler` to allow the thread to be interrupted while waiting for user input.

This allows for a longer timeout on waiting for input, so the thread stay waiting until input is received, instead of waking up every 10th of a second.