### PR TITLE
Create Better Methods for Log

### DIFF
--- a/inc/log.hpp
+++ b/inc/log.hpp
@@ -20,6 +20,8 @@ public:
 		friend std::ostream& operator<<(std::ostream&, const Entry&);
 	};
 
+	static Entry makeEntry(std::string, Entry::LogType, std::string);
+
 	Log(std::string, std::string);
 	Log(std::string, std::string, Log*);
 	virtual ~Log();
@@ -29,6 +31,9 @@ public:
 	void log(std::string);
 	void log(std::string, Entry::LogType);
 	void log(std::string, Entry::LogType, std::string);
+
+	friend void operator<<(Log&, const std::string&);
+	friend void operator<<(Log&, const Entry&);
 
 private:
 	void writeEntry(Entry);

--- a/inc/log.hpp
+++ b/inc/log.hpp
@@ -21,6 +21,7 @@ public:
 	};
 
 	static Entry makeEntry(std::string, Entry::LogType, std::string);
+	static Entry makeEntry(Entry, std::string);
 
 	Log(std::string, std::string);
 	Log(std::string, std::string, Log*);

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -13,6 +13,12 @@ using std::chrono::system_clock;
 //Must construct in-place because ofstream is non-copyable
 Log Engine::log{"Master", "./logs/master.log", nullptr};
 
+
+Log::Entry Log::makeEntry(std::string message, Log::Entry::LogType severity, std::string sender) {
+	return Log::Entry{system_clock::now(), severity, message, sender};
+};
+
+
 Log::Log(std::string name, std::string logfile) : Log(name, logfile, &Engine::log){};
 
 Log::Log(std::string name, std::string logfile, Log *parent) {
@@ -32,11 +38,11 @@ void Log::setParent(Log *parent) {
 };
 
 void Log::log(std::string message) {
-	this->log(message, Log::Entry::LogType::Info, "");
+	this->log(message, Log::Entry::LogType::Info, "Default");
 };
 
 void Log::log(std::string message, Log::Entry::LogType severity) {
-	this->log(message, severity, "");
+	this->log(message, severity, "Default");
 };
 
 void Log::log(std::string message, Log::Entry::LogType severity, std::string sender) {
@@ -87,4 +93,12 @@ std::ostream& operator<<(std::ostream &os, const Log::Entry &entry) {
 	os << " : " << entry.message;
 
 	return os;
+};
+
+void operator<<(Log &log, const std::string &message) {
+	log.log(message);
+};
+
+void operator<<(Log &log, const Log::Entry &entry) {
+	log.writeEntry(entry);
 };

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -13,9 +13,20 @@ using std::chrono::system_clock;
 //Must construct in-place because ofstream is non-copyable
 Log Engine::log{"Master", "./logs/master.log", nullptr};
 
-
+/*
+ * Creates entry with given message, severity, and sender
+ * Sets timestamp to current time
+ */
 Log::Entry Log::makeEntry(std::string message, Log::Entry::LogType severity, std::string sender) {
 	return Log::Entry{system_clock::now(), severity, message, sender};
+};
+
+/*
+ * Pulls severity and sender for new Entry from base
+ * Replaces message and timestamp with new values
+ */
+Log::Entry Log::makeEntry(Log::Entry base, std::string message) {
+	return Log::makeEntry(message, base.severity, base.sender);
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,8 @@ int main() {
 	Log testLog{"Test", "./logs/test.log"};
 	LogType testLogType = LogType::Debug;
 	testLog.log("Testing nested log", LogType::Info, "Main");
+	testLog << "Testing log insertion operator for message";
+	testLog << Log::makeEntry("Test log insertion operator for Entry", testLogType, "Main");
 	Engine::log.log("Initialization complete", LogType::Info, "Main");
 
 	//Print out manager

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,8 @@ int main() {
 	LogType testLogType = LogType::Debug;
 	testLog.log("Testing nested log", LogType::Info, "Main");
 	testLog << "Testing log insertion operator for message";
-	testLog << Log::makeEntry("Test log insertion operator for Entry", testLogType, "Main");
+	Log::Entry testLogEntry = Log::makeEntry("BaseEntry", testLogType, "Main");
+	testLog << Log::makeEntry(testLogEntry, "Test log insertion operator for Entry");
 	Engine::log.log("Initialization complete", LogType::Info, "Main");
 
 	//Print out manager


### PR DESCRIPTION
Contains enhancements for logging.

Log now overloads `operator<<` to allow for easier insertion.  There are overloads for `std::string` and `Log::Entry`.

A static method `makeEntry` has been added to `Log`.  This method creates a `Log::Entry` with the same arguments as the full `Log::log` method.  An overload was added that takes arguments of `Log::Entry base` and `std::string message`; this uses the severity and sender from `base` to create a new `Log::Entry` with the given `message` and a new timestamp.